### PR TITLE
Fix empty values not removed from highlight_ids field

### DIFF
--- a/manager/registry.py
+++ b/manager/registry.py
@@ -332,7 +332,7 @@ class Field:
         if self.id == "highlight_ids":
             value = form.get(self.id)
             value = value.replace(",", "|").replace("\n", "|")
-            return [i.rstrip().lstrip() for i in value.split("|")]
+            return [i for i in [j.rstrip().lstrip() for j in value.split("|")] if i]
 
         if self.multiple:
             if (


### PR DESCRIPTION
The metadata manager was not properly filtering empty string values from the highlight_ids field when processing form submissions. This caused the data discovery application to display enabled "show coverage" buttons even when there were no actual highlight IDs to display on the map.

**Root Cause:**
Empty strings ('') in the highlight_ids array were being preserved during form processing
The frontend treated arrays with empty strings as having content (non-zero length)
This resulted in misleading UI where buttons appeared enabled but had no data to show

**Solution**
Modified the get_value_from_form method in manager/registry.py to filter out empty strings from the highlight_ids array:

**Testing**
Verified the fix with comprehensive test cases:
✅ Normal comma-separated values: 'id1,id2,id3' → ['id1', 'id2', 'id3']
✅ Empty values mixed in: 'id1,,id3' → ['id1', 'id3']
✅ Only empty values: ',,,' → []
✅ Empty input: '' → []
✅ Newline-separated values: 'id1\n\nid3' → ['id1', 'id3']