### PR TITLE
fix: support running Docker build on arm64 arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster
+FROM --platform=linux/amd64 python:3.8-slim-buster
 
 # Switch to new user "herop"
 RUN useradd -m herop


### PR DESCRIPTION
## Problem
Docker image build fails on M1 Macbook (`arm64` arch):
```bash
#10 9.082   × Getting requirements to build wheel did not run successfully.
#10 9.082   │ exit code: 1
#10 9.082   ╰─> [2 lines of output]
#10 9.082       WARNING:root:Failed to get options via gdal-config: [Errno 2] No such file or directory: 'gdal-config'
#10 9.082       CRITICAL:root:A GDAL API version must be specified. Provide a path to gdal-config using a GDAL_CONFIG environment variable or use a GDAL_VERSION environment variable.
#10 9.082       [end of output]
```


## Approach
* fix: hardcode `--platform=linux/amd64` in first line of Dockerfile

This will use Docker's emulation engine to build the image without needing the external GDAL install


### ⚠️ Warnings
NOTE: this will produce some warnings in the log output

it is safe to ignore these for our case, but if we were distributing software for people to install this would not be a good pattern.

During the Docker build:
```
#2 WARN: FromPlatformFlagConstDisallowed: FROM --platform flag should not use constant value "linux/amd64" (line 1)
```

When running the image/compose services after building:
```bash
#14 exporting to image
#14 exporting layers
#14 exporting layers 9.0s done
#14 exporting manifest sha256:3d1de0ffb192a07fb81d85f4999a0e1c4a31886644e1441a5b6b0df1b2738750 done
#14 exporting config sha256:f1eff1e728d57c613e1071d9f636c212c75a0c33e6b93bcbca1b5e72d2a19875 done
#14 exporting attestation manifest sha256:afb75d928288605bcce0b19b24bc4d35b1becf1144de94db9e6cfdf507951bd5 done
#14 exporting manifest list sha256:a0cdd97c3a1c706473ff6f1e9b830fec8d90cb97d071d51c03b2ef40e40b93ea done
#14 naming to docker.io/herop/sdoh-metadata-manager:latest done
#14 unpacking to docker.io/herop/sdoh-metadata-manager:latest
#14 unpacking to docker.io/herop/sdoh-metadata-manager:latest 1.8s done
#14 DONE 10.9s

#15 resolving provenance for metadata file
#15 DONE 0.0s
[+] Running 4/4
 ✔ herop/sdoh-metadata-manager                                                                                                                            Built                      0.0s 
 ✔ Container sdoh-manager                                                                                                                                 Started                   18.8s 
 ✔ Container sdoh-solr                                                                                                                                    H...                       8.1s 
 ! manager The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested        
```
It is safe to ignore these warnings for now, since we are only targeting a single release platform (`linux/amd64` for hosts)

## How to Test
1. Checkout and run this branch locally: `docker compose up -d --build`
    * You should see the image build successfully regardless of the type of host machine